### PR TITLE
Add Unit / Delete Unit Functionality

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -205,8 +205,13 @@ class App extends Component {
         .then((deleteUnitResponse) => {
         console.log('delete unit response', deleteUnitResponse);
 
+        const redirectUnit = this.state.units[deleteUnitResponse.length - 1];
+
+        console.log('redirectUnit', redirectUnit)
+
         this.setState({
           units: deleteUnitResponse,
+          currentUnitData: redirectUnit,
           postDidMount: true,
         })
       })

--- a/client/App.js
+++ b/client/App.js
@@ -38,8 +38,13 @@ class App extends Component {
     // Updates the state with the current selection of units. Slices off the dynamically
     // generated ID from the NavBar component at the last index of the string. This ID
     // will be used to render the info comps below our nav based on selection -mp
-    const currentUnitId = Number(event.target.id.slice(event.target.id.length - 1)) - 1;
+    console.log('eventTarget', event.target.id)
+    let currentUnitId = event.target.id.split(' ');
+    currentUnitId = Number(currentUnitId[currentUnitId.length - 1]);
+
     const currentUnitData = this.state.units[currentUnitId];
+
+    console.log('current unit id', currentUnitId);
 
     this.setState({
       currentUnitIndex: currentUnitId,
@@ -153,7 +158,7 @@ class App extends Component {
   // functions to add a unit
   addUnit() {
     // Function to add a new flashCard to our database
-    const addUnitURL = `/units/${ this.state.currentUnitData.id.toString() }`
+    const addUnitURL = `/units/add-unit`
 
     fetch(addUnitURL, {
       method: 'POST',

--- a/client/App.js
+++ b/client/App.js
@@ -22,7 +22,7 @@ class App extends Component {
       currentFlashCards: null,
       currentResources: null,
       question: true,
-      questionsArray: [],
+      questionsArray: [true],
     }
 
     this.updateCurrentUnit = this.updateCurrentUnit.bind(this);

--- a/client/App.js
+++ b/client/App.js
@@ -204,10 +204,8 @@ class App extends Component {
       }).then(response => response.json())
         .then((deleteUnitResponse) => {
         console.log('delete unit response', deleteUnitResponse);
-
+        // Sets a redirect current unit after delete
         const redirectUnit = this.state.units[deleteUnitResponse.length - 1];
-
-        console.log('redirectUnit', redirectUnit)
 
         this.setState({
           units: deleteUnitResponse,

--- a/client/App.js
+++ b/client/App.js
@@ -38,13 +38,11 @@ class App extends Component {
     // Updates the state with the current selection of units. Slices off the dynamically
     // generated ID from the NavBar component at the last index of the string. This ID
     // will be used to render the info comps below our nav based on selection -mp
-    console.log('eventTarget', event.target.id)
     let currentUnitId = event.target.id.split(' ');
+
     currentUnitId = Number(currentUnitId[currentUnitId.length - 1]);
 
     const currentUnitData = this.state.units[currentUnitId];
-
-    console.log('current unit id', currentUnitId);
 
     this.setState({
       currentUnitIndex: currentUnitId,

--- a/client/App.js
+++ b/client/App.js
@@ -31,6 +31,7 @@ class App extends Component {
     this.deleteFlashCard = this.deleteFlashCard.bind(this);
     this.flipFlashCard = this.flipFlashCard.bind(this);
     this.flashCardQuestionAnswers = this.flashCardQuestionAnswers.bind(this);
+    this.addUnit = this.addUnit.bind(this);
   }
 
   // Nav Bar functionality
@@ -157,6 +158,9 @@ class App extends Component {
   addUnit() {
     // Function to add a new flashCard to our database
     const addUnitURL = `/units/add-unit`
+    const unitName = document.getElementById('unit-name');
+    const unitDescription = document.getElementById('unit-description');
+    const subUnits = document.getElementById('sub-units');
 
     fetch(addUnitURL, {
       method: 'POST',
@@ -164,13 +168,17 @@ class App extends Component {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        unit: document.getElementById('unit-name').value,
-        description: document.getElementById('unit-description').value,
-        sub_units: document.getElementById('sub-units').value,
+        unit: unitName.value,
+        description: unitDescription.value,
+        sub_units: subUnits.value,
       }),
     }).then((response) => response.json())
       .then((newUnitResponse) => {
         console.log('new unit response', newUnitResponse);
+
+        unitName.value = '';
+        unitDescription.value = '';
+        subUnits.value = '';
 
         this.setState({
           units: newUnitResponse,

--- a/client/App.js
+++ b/client/App.js
@@ -32,6 +32,7 @@ class App extends Component {
     this.flipFlashCard = this.flipFlashCard.bind(this);
     this.flashCardQuestionAnswers = this.flashCardQuestionAnswers.bind(this);
     this.addUnit = this.addUnit.bind(this);
+    this.deleteUnit = this.deleteUnit.bind(this);
   }
 
   // Nav Bar functionality
@@ -154,7 +155,7 @@ class App extends Component {
     this.setState({ questionsArray: currentAnswersStateArray });
   }
 
-  // functions to add a unit
+  // functions to add and delete a unit
   addUnit() {
     // Function to add a new flashCard to our database
     const addUnitURL = `/units/add-unit`
@@ -186,6 +187,30 @@ class App extends Component {
         })
       })
       .catch(err => console.log('error in New Unit Response:', err));
+  }
+
+  deleteUnit(cardId) {
+    /// Function to delete a flashCard in our database
+    const deleteUnitURL = `/units/delete-unit`
+
+    fetch(deleteUnitURL, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        id: cardId,
+      }),
+      }).then(response => response.json())
+        .then((deleteUnitResponse) => {
+        console.log('delete unit response', deleteUnitResponse);
+
+        this.setState({
+          units: deleteUnitResponse,
+          postDidMount: true,
+        })
+      })
+        .catch(err => console.log('error in deleteUnit:', err));
   }
   // passed to lower components to update state in App.js
   updateDrilledState(updateObject){
@@ -241,6 +266,7 @@ class App extends Component {
                 questionsArray={ this.state.questionsArray }
                 // Add Unit Props
                 addUnit={ this.addUnit }
+                deleteUnit={ this.deleteUnit }
               />
             </Route>
             <Route path='/sign-up'>

--- a/client/App.js
+++ b/client/App.js
@@ -168,10 +168,13 @@ class App extends Component {
         description: document.getElementById('unit-description').value,
         sub_units: document.getElementById('sub-units').value,
       }),
-    }).then(response => response.json())
+    }).then((response) => response.json())
       .then((newUnitResponse) => {
+        console.log('new unit response', newUnitResponse);
+
         this.setState({
           units: newUnitResponse,
+          postDidMount: true,
         })
       })
       .catch(err => console.log('error in New Unit Response:', err));

--- a/client/components/NavBar.jsx
+++ b/client/components/NavBar.jsx
@@ -11,7 +11,7 @@ function NavBar (props) {
   // However... prior group set the DB ID's for units out of order as well. Will look
   // into changing if possible.
   for (let i = unitsArr.length - 1; i >= 0 ; i -= 1) {
-    unitsLinks.push(<li key={ `nav-bar list item ${ unitsArr[i].id }` }><Link to="/main-container/units" id={`nav-bar-id${ unitsArr[i].id }`} onClick={ (e) => props.updateCurrentUnit(e) }>{ unitsArr[i].unit }</Link></li>)
+    unitsLinks.push(<li key={ `nav-bar list item${ i }` }><Link to="/main-container/units" id={`nav-bar-id ${ i }`} onClick={ (e) => props.updateCurrentUnit(e) }>{ unitsArr[i].unit }</Link></li>)
   }
 
   return (

--- a/client/components/NewUnitModal.jsx
+++ b/client/components/NewUnitModal.jsx
@@ -11,7 +11,7 @@ function NewUnitModal (props) {
           <input id="unit-description" type="text" name="unit-description" /><br></br>
           Sub-Units:<br></br>
           <input id="sub-units" type="text" name="sub-units" /><br></br>
-          <input type="submit" value="Submit"></input>
+          <button onClick={ props.addUnit } value="Add Unit" className="addUnit" type="button">Add Unit</button>
         </form>
     </div>
   )

--- a/client/components/NewUnitModal.jsx
+++ b/client/components/NewUnitModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from "react-router-dom";
 
 function NewUnitModal (props) {
   return (
@@ -11,7 +12,7 @@ function NewUnitModal (props) {
           <input id="unit-description" type="text" name="unit-description" /><br></br>
           Sub-Units:<br></br>
           <input id="sub-units" type="text" name="sub-units" /><br></br>
-          <button onClick={ props.addUnit } value="Add Unit" className="addUnit" type="button">Add Unit</button>
+          <Link to="/main-container"><button onClick={ props.addUnit } value="Add Unit" className="addUnit" type="button">Add Unit</button></Link>
         </form>
     </div>
   )

--- a/client/containers/FlashCardsContainer.jsx
+++ b/client/containers/FlashCardsContainer.jsx
@@ -6,6 +6,8 @@ class FlashCardsContainer extends Component {
   render() {
     const flashCardsArr = [];
 
+    console.log('flash cards', this.props.flashCards)
+
     for (let i = 0; i < this.props.flashCards.length; i+= 1) {
       const { id, unit_id, question, answer} = this.props.flashCards[i];
 

--- a/client/containers/MainContainer.jsx
+++ b/client/containers/MainContainer.jsx
@@ -34,6 +34,7 @@ function MainContainer (props) {
               flipFlashCard={ props.flipFlashCard }
               flashCardQuestionAnswers={ props.flashCardQuestionAnswers }
               questionsArray={ props.questionsArray }
+              deleteUnit={ props.deleteUnit }
             />
               : <div></div>
             }

--- a/client/containers/MainContainer.jsx
+++ b/client/containers/MainContainer.jsx
@@ -39,7 +39,9 @@ function MainContainer (props) {
             }
           </Route>
           <Route path='/main-container/create-unit'>
-            <NewUnitContainer />
+            <NewUnitContainer
+              addUnit={ props.addUnit }
+            />
           </Route>
         </Switch>
     </div>

--- a/client/containers/NewUnitContainer.jsx
+++ b/client/containers/NewUnitContainer.jsx
@@ -5,7 +5,9 @@ class NewUnitContainer extends React.Component {
   render () {
     return (
       <section>
-        <NewUnitModal />
+        <NewUnitModal
+          addUnit={ this.addUnit }
+        />
       </section>
     )
   }

--- a/client/containers/NewUnitContainer.jsx
+++ b/client/containers/NewUnitContainer.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import NewUnitModal from '../components/NewUnitModal.jsx';
 
-class NewUnitContainer extends React.Component {
-  render () {
-    return (
-      <section>
-        <NewUnitModal
-          addUnit={ this.addUnit }
-        />
-      </section>
-    )
-  }
+function NewUnitContainer (props) {
+  return (
+    <section>
+      <NewUnitModal
+        addUnit={ props.addUnit }
+      />
+    </section>
+  )
 }
 
 export default NewUnitContainer;

--- a/client/containers/UnitContainer.jsx
+++ b/client/containers/UnitContainer.jsx
@@ -64,6 +64,7 @@ class UnitContainer extends React.Component {
                   />
                 <Resources
                   resources={ this.props.currentResources } />
+                <button onClick={() => this.props.deleteUnit(this.props.currentUnitData.id.toString())} className="deleteUnit" type="button">Delete Unit</button>
               </div>
               :
             <div></div> }

--- a/client/containers/UnitContainer.jsx
+++ b/client/containers/UnitContainer.jsx
@@ -13,7 +13,14 @@ class UnitContainer extends React.Component {
       .then((response) => response.json())
       .then((data) => {
         // console.log('flashCard Data', data.flashCards.length)
-        const questionAnswerArray = this.props.flashCardQuestionAnswers(data.flashCards.length)
+        let questionAnswerArray = [];
+        // if it's a new card (with no questions) we will push a true to questionsArray,
+        // as its required for conditional rendering
+        if (data.flashCards.length <= 0) questionAnswerArray.push(true);
+        // if it's an existing card with questions, we will populate the array based on
+        // length of questions array
+        else questionAnswerArray = this.props.flashCardQuestionAnswers(data.flashCards.length)
+
         this.props.updateDrilledState({
             questionsArray: questionAnswerArray,
             currentFlashCards: data.flashCards,
@@ -57,8 +64,9 @@ class UnitContainer extends React.Component {
                   />
                 <Resources
                   resources={ this.props.currentResources } />
-              </div> :
-              <div></div> }
+              </div>
+              :
+            <div></div> }
         </div>
       </div>
     );

--- a/client/style/index.css
+++ b/client/style/index.css
@@ -60,9 +60,10 @@ h4 {
   display: flex;
   justify-content: center;
   list-style-type: none;
-  /* flex-direction: column; */
+  flex-wrap: wrap;
 }
 #navbarList a {
+  display: flex;
   color: white;
   flex: 1;
   list-style-type: none;

--- a/server/routes/unitsRouter.js
+++ b/server/routes/unitsRouter.js
@@ -27,7 +27,7 @@ unitsRouter.get('/',
     res.status(200).json(res.locals.units)
   });
 
-  unitsRouter.delete('/delete-unit/:id',
+  unitsRouter.delete('/delete-unit/',
   unitControllers.deleteUnits,
   unitControllers.getUnits,
   (req, res) => {


### PR DESCRIPTION
This pull includes updates to:

**New Unit Functionality**
Adding a new unit now renders on the page and redirects to the main-container using react-router. 
Squashed bugs which include conditional rendering of the unit descriptions relying on the questionsArray state object. Also kept the index of the newly rendered Nav buttons in line with their generated for loop as apposed to their unit_id which comes from the database, as deletes and adds would leave gaps in these numbers/indexes.

**Delete Unit Functionality**
You can now delete cards and properly re-render the page with the correct number of Nav buttons. Page also redirects to an exiting card upon deletion.